### PR TITLE
chore: release v0.11.0-beta.8

### DIFF
--- a/siumai-bridge/CHANGELOG.md
+++ b/siumai-bridge/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/releases/tag/siumai-bridge-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- lock bridge stable stream parts
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- converge fearless architecture boundaries

--- a/siumai-core/CHANGELOG.md
+++ b/siumai-core/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-core-v0.11.0-beta.7...siumai-core-v0.11.0-beta.8) - 2026-05-18
+
+### Added
+
+- reconnect google interactions streams
+
+### Fixed
+
+- *(openai-compatible)* preserve whitespace stream deltas
+
+### Other
+
+- guard core standards boundary
+- *(clippy)* clean release lint failures
+- *(release)* prepare v0.11.0-beta.8
+- *(openai-compatible)* enforce lossless stream deltas
+- harden spec core architecture guards
+- remove static-header json executor helper
+- remove dedicated vision compatibility surface
+- route stream text fallback through response adapter
+- converge provider boundary architecture
+- move provider model aliases out of core
+- harden crate boundaries
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- *(deps)* refresh integration dependencies
+- clean stale refactor docs
+
 ### Added
 
 - Add a first-class completion family surface: `traits::CompletionCapability`,

--- a/siumai-extras/CHANGELOG.md
+++ b/siumai-extras/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-extras-v0.11.0-beta.7...siumai-extras-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- cover extras stable stream bridge
+- lock bridge stable stream parts
+- require stable gateway tool parts
+- *(clippy)* clean release lint failures
+- *(release)* prepare v0.11.0-beta.8
+- harden extras boundary and audit evidence
+- converge provider boundary architecture
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- *(examples)* modernize MCP and tool-loop demos
+- *(deps)* refresh integration dependencies
+- clean stale refactor docs
+
 ### Added
 
 - Runnable loss-policy bridge example:

--- a/siumai-protocol-anthropic/CHANGELOG.md
+++ b/siumai-protocol-anthropic/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-protocol-anthropic-v0.11.0-beta.7...siumai-protocol-anthropic-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- guard protocol custom stream inputs
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Fixed
 
 - Anthropic header construction now supports the audited alternate-auth path: when callers provide

--- a/siumai-protocol-gemini/CHANGELOG.md
+++ b/siumai-protocol-gemini/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-protocol-gemini-v0.11.0-beta.7...siumai-protocol-gemini-v0.11.0-beta.8) - 2026-05-18
+
+### Fixed
+
+- *(gemini)* gate structured response content branch
+- repair release test regressions
+
+### Other
+
+- guard protocol custom stream inputs
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Fixed
 
 - Gemini embedding response transformation now preserves an AI SDK-style response envelope with

--- a/siumai-protocol-openai/CHANGELOG.md
+++ b/siumai-protocol-openai/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-protocol-openai-v0.11.0-beta.7...siumai-protocol-openai-v0.11.0-beta.8) - 2026-05-18
+
+### Added
+
+- align openai metadata package surface
+- *(openai)* support responses allowed tools option
+- *(openai)* support gpt-image-2 image model
+
+### Fixed
+
+- require explicit compat completion capabilities
+- *(openai-compatible)* extract generic response metadata
+- *(openai)* preserve empty responses deltas
+- *(openai)* preserve lossless stream deltas
+- *(openai-compatible)* preserve whitespace stream deltas
+- *(openai)* align image provider option wire keys
+- *(openai)* align model capability gating with ai sdk
+
+### Other
+
+- *(openai-compatible)* centralize reasoning policy
+- *(openai-compatible)* centralize usage policy
+- prefer stable responses stream parts
+- *(clippy)* clean release lint failures
+- *(release)* prepare v0.11.0-beta.8
+- *(openai)* unify completion request shaping
+- *(openai)* unify completion response metadata
+- *(openai)* unify completion metadata helpers
+- *(openai-compatible)* enforce lossless stream deltas
+- converge provider boundary architecture
+- harden crate boundaries
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Fixed
 
 - OpenAI-compatible rerank response transformation now preserves an AI SDK-style response envelope

--- a/siumai-provider-amazon-bedrock/CHANGELOG.md
+++ b/siumai-provider-amazon-bedrock/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-amazon-bedrock-v0.11.0-beta.7...siumai-provider-amazon-bedrock-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- *(bedrock)* isolate chat stream conversion
+- *(bedrock)* isolate chat standard tests
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - Native Bedrock provider now also exposes package-level `AmazonBedrockProviderSettings` plus

--- a/siumai-provider-anthropic-compatible/CHANGELOG.md
+++ b/siumai-provider-anthropic-compatible/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-anthropic-compatible-v0.11.0-beta.7...siumai-provider-anthropic-compatible-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ## [0.11.0-beta.5] - 2026-01-15
 
 ### Added

--- a/siumai-provider-anthropic/CHANGELOG.md
+++ b/siumai-provider-anthropic/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-anthropic-v0.11.0-beta.7...siumai-provider-anthropic-v0.11.0-beta.8) - 2026-05-18
+
+### Fixed
+
+- align anthropic files capability surface
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - Native Anthropic now exposes an AI SDK-style package settings wrapper:

--- a/siumai-provider-azure/CHANGELOG.md
+++ b/siumai-provider-azure/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-azure-v0.11.0-beta.7...siumai-provider-azure-v0.11.0-beta.8) - 2026-05-18
+
+### Added
+
+- align azure metadata package surface
+
+### Fixed
+
+- repair release test regressions
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - Native Azure OpenAI provider now also exposes package-level `AzureOpenAIProviderSettings` plus

--- a/siumai-provider-cohere/CHANGELOG.md
+++ b/siumai-provider-cohere/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-cohere-v0.11.0-beta.7...siumai-provider-cohere-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - Native Cohere `/v2` support now covers chat, embeddings, and rerank from the same provider

--- a/siumai-provider-deepseek/CHANGELOG.md
+++ b/siumai-provider-deepseek/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-deepseek-v0.11.0-beta.7...siumai-provider-deepseek-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - The provider-owned typed surface now exposes AI SDK-style `DeepSeekLanguageModelOptions` with

--- a/siumai-provider-gemini/CHANGELOG.md
+++ b/siumai-provider-gemini/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-gemini-v0.11.0-beta.7...siumai-provider-gemini-v0.11.0-beta.8) - 2026-05-18
+
+### Added
+
+- reconnect google interactions streams
+- stream google interactions events
+- execute google interactions non-stream requests
+- parse google interactions responses
+- add google interactions agent request conversion
+- add google interactions request conversion
+- expose google interactions package boundary
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Fixed
 
 - Gemini content-part metadata helpers now include stable `reasoning-file` and `custom` parts so

--- a/siumai-provider-google-vertex/CHANGELOG.md
+++ b/siumai-provider-google-vertex/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-google-vertex-v0.11.0-beta.7...siumai-provider-google-vertex-v0.11.0-beta.8) - 2026-05-18
+
+### Added
+
+- align google vertex root aliases
+
+### Other
+
+- *(clippy)* clean release lint failures
+- *(release)* prepare v0.11.0-beta.8
+- route vertex image prompt through request adapter
+- converge provider boundary architecture
+- harden crate boundaries
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - The provider-owned/public Google Vertex surface now exposes the audited upstream primary

--- a/siumai-provider-groq/CHANGELOG.md
+++ b/siumai-provider-groq/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-groq-v0.11.0-beta.7...siumai-provider-groq-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+﻿
 ### Added
 
 - Added AI SDK-style `GroqProviderSettings` and `VERSION` exports for the audited package-level

--- a/siumai-provider-minimaxi/CHANGELOG.md
+++ b/siumai-provider-minimaxi/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-minimaxi-v0.11.0-beta.7...siumai-provider-minimaxi-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - MiniMaxi now exposes a provider-owned curated model surface for the public families (`chat`,

--- a/siumai-provider-ollama/CHANGELOG.md
+++ b/siumai-provider-ollama/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-ollama-v0.11.0-beta.7...siumai-provider-ollama-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- reuse builtin registry helper for ollama parity tests
+- harden crate boundaries
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - Ollama now exposes a provider-owned curated `models` surface for `chat` plus `embedding`, and

--- a/siumai-provider-openai-compatible/CHANGELOG.md
+++ b/siumai-provider-openai-compatible/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-openai-compatible-v0.11.0-beta.7...siumai-provider-openai-compatible-v0.11.0-beta.8) - 2026-05-18
+
+### Added
+
+- add google vertex xai provider boundary
+
+### Fixed
+
+- require explicit compat completion capabilities
+
+### Other
+
+- *(openai-compatible)* centralize reasoning policy
+- *(openai-compatible)* centralize usage policy
+- fix openai compatible settings formatting
+- *(release)* prepare v0.11.0-beta.8
+- *(openai-compatible)* isolate settings tests
+- *(openai-compatible)* isolate builder tests
+- *(openai-compatible)* isolate request option tests
+- *(openai-compatible)* split builder reasoning mapping
+- *(openai-compatible)* split builtin provider registry
+- *(openai-compatible)* split provider family defaults
+- *(openai-compatible)* converge simple provider settings
+- *(openai-compatible)* split completion runtime boundary
+- *(openai-compatible)* isolate client shell tests
+- *(openai-compatible)* split client shell boundaries
+- *(openai-compatible)* split provider model catalog
+- *(openai-compatible)* isolate model listing module
+- *(openai-compatible)* isolate audio client module
+- *(openai-compatible)* isolate rerank client module
+- *(openai-compatible)* isolate image client module
+- *(openai-compatible)* isolate embedding client module
+- *(openai-compatible)* isolate chat client module
+- *(openai-compatible)* isolate completion client module
+- *(openai)* unify completion request shaping
+- *(openai)* unify completion response metadata
+- *(openai)* unify completion metadata helpers
+- *(openai-compatible)* enforce lossless stream deltas
+- converge provider boundary architecture
+- move provider model aliases out of core
+- harden crate boundaries
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+﻿
 ### Added
 
 - Add compat-backed AI SDK-style `DeepSeekProviderSettings`, `GroqProviderSettings`,

--- a/siumai-provider-openai/CHANGELOG.md
+++ b/siumai-provider-openai/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-openai-v0.11.0-beta.7...siumai-provider-openai-v0.11.0-beta.8) - 2026-05-18
+
+### Added
+
+- align openai metadata package surface
+- *(openai)* align model catalog with ai sdk
+- *(openai)* support responses allowed tools option
+- *(openai)* support gpt-image-2 image model
+
+### Fixed
+
+- *(openai)* preserve lossless stream deltas
+- *(openai)* align image provider option wire keys
+- *(openai)* align model capability gating with ai sdk
+
+### Other
+
+- *(clippy)* clean release lint failures
+- *(release)* prepare v0.11.0-beta.8
+- *(openai)* unify completion request shaping
+- *(openai)* unify completion response metadata
+- *(openai)* unify completion metadata helpers
+- converge provider boundary architecture
+- harden crate boundaries
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - Native OpenAI provider now also exposes a provider-owned `skills()` resource aligned with the

--- a/siumai-provider-togetherai/CHANGELOG.md
+++ b/siumai-provider-togetherai/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-togetherai-v0.11.0-beta.7...siumai-provider-togetherai-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - Add public `TogetherAiImageOptions` plus `TogetherAiImageRequestExt` for

--- a/siumai-provider-xai/CHANGELOG.md
+++ b/siumai-provider-xai/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-xai-v0.11.0-beta.7...siumai-provider-xai-v0.11.0-beta.8) - 2026-05-18
+
+### Other
+
+- *(release)* prepare v0.11.0-beta.8
+- converge provider boundary architecture
+- harden crate boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+﻿
 ### Added
 
 - Added AI SDK-style `XaiProviderSettings` and `VERSION` exports for the audited package-level

--- a/siumai-registry/CHANGELOG.md
+++ b/siumai-registry/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-registry-v0.11.0-beta.7...siumai-registry-v0.11.0-beta.8) - 2026-05-18
+
+### Added
+
+- add google vertex xai provider boundary
+
+### Fixed
+
+- align anthropic files capability surface
+- require explicit compat completion capabilities
+- repair release test regressions
+
+### Other
+
+- *(clippy)* align provider feature gates
+- lock xai package files boundary
+- clarify togetherai audio extension boundary
+- lock groq provider-owned speech boundary
+- lock registry compat handle boundaries
+- *(clippy)* clean release lint failures
+- *(release)* prepare v0.11.0-beta.8
+- mark registry family adapters removed
+- align ProviderFactory compatibility audit
+- isolate provider composite clients
+- isolate language extension handle adapters
+- remove vision builder capability hint
+- remove provider-type builder alias
+- remove registry speech handle tts alias
+- remove static-header json executor helper
+- remove dedicated vision compatibility surface
+- migrate openai compatible override shortcuts
+- migrate core provider override shortcuts
+- migrate openai compatible registry overrides
+- migrate vertex registry overrides
+- migrate minimaxi registry overrides
+- migrate groq registry overrides
+- migrate anthropic registry overrides
+- migrate bedrock registry overrides
+- migrate xai registry overrides
+- migrate ollama registry overrides
+- migrate vertex maas registry overrides
+- migrate public path registry overrides
+- centralize registry option defaults
+- add provider build override shortcuts
+- move builder default models into registry metadata
+- route facade parity registries through helpers
+- guard public path registry helper boundary
+- route openai compatible registries through helper
+- route azure registry factory options through helper
+- converge provider boundary architecture
+- centralize builtin registry factory resolution
+- move provider model aliases out of core
+- harden crate boundaries
+- converge fearless architecture boundaries
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - Add completion-family registry plumbing: `ProviderFactory::completion_model_family*`,

--- a/siumai-spec/CHANGELOG.md
+++ b/siumai-spec/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-spec-v0.11.0-beta.7...siumai-spec-v0.11.0-beta.8) - 2026-05-18
+
+### Added
+
+- add google vertex xai provider boundary
+
+### Other
+
+- *(clippy)* derive default for http config
+- *(release)* prepare v0.11.0-beta.8
+- harden spec core architecture guards
+- remove dedicated vision compatibility surface
+- converge provider boundary architecture
+- *(examples)* move extras example index
+- *(examples)* tighten example guidance
+- clean stale refactor docs
+
 ### Added
 
 - Add shared `ProviderMetadataMap` helpers aligned with AI SDK `ProviderMetadata`:


### PR DESCRIPTION



## 🤖 New release

* `siumai-spec`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-core`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-protocol-anthropic`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-protocol-gemini`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-protocol-openai`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-bridge`: 0.11.0-beta.8
* `siumai-provider-amazon-bedrock`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-anthropic`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-azure`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-cohere`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-openai-compatible`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-deepseek`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-gemini`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-google-vertex`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-groq`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-minimaxi`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-ollama`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-openai`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-togetherai`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-xai`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-registry`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-extras`: 0.11.0-beta.7 -> 0.11.0-beta.8
* `siumai-provider-anthropic-compatible`: 0.11.0-beta.7 -> 0.11.0-beta.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `siumai-spec`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-spec-v0.11.0-beta.7...siumai-spec-v0.11.0-beta.8) - 2026-05-18

### Added

- add google vertex xai provider boundary

### Other

- *(clippy)* derive default for http config
- *(release)* prepare v0.11.0-beta.8
- harden spec core architecture guards
- remove dedicated vision compatibility surface
- converge provider boundary architecture
- *(examples)* move extras example index
- *(examples)* tighten example guidance
- clean stale refactor docs

### Added

- Add shared `ProviderMetadataMap` helpers aligned with AI SDK `ProviderMetadata`:
  `provider_metadata_object`, `provider_metadata_value`, `provider_metadata_from_object`, and
  `merge_provider_metadata` now centralize the stable `provider_id -> object` contract used by
  response-side provider metadata.
- Add shared Groq provider-tool helpers aligned with AI SDK `browserSearch()`:
  `tools::groq::browser_search()` and `provider_defined_tool("groq.browser_search")` now build the
  stable `Tool::ProviderDefined` shape with the canonical `browser_search` default name.
- Add canonical `providerOptions` to shared file uploads through `FileUploadRequest`, bringing the
  stable file-upload request shape closer to AI SDK `FilesV4UploadFileCallOptions`.
- Add a stable AI SDK-aligned completion family: `CompletionRequest` now keeps a structured
  prompt plus `tools`, `tool_choice`, `common_params`, `response_format`, `provider_options_map`,
  and per-request `HttpConfig`, while `CompletionResponse` carries generated text, finish reason,
  usage, warnings, response metadata, and provider metadata.
- Add the Vercel-aligned `Warning::Compatibility` variant and helper constructor.
- Add the AI SDK-style `Warning::Unsupported { feature, details }` variant and normalize helper constructors to emit that shared shape while keeping legacy unsupported warning variants for compatibility.
- `Usage` now makes AI SDK-style `inputTokens` / `outputTokens` / `raw` the canonical stable layer, while legacy `prompt/completion/total` counts remain available through compatibility accessors/serde plus normalized helper APIs for migration-safe provider/protocol code.
- Extend unified `source` parts with optional `mediaType`, `filename`, and `providerMetadata` fields for document-style sources.
- Refactor unified `source` parts into a stricter AI SDK-style URL/document union via `SourcePart`, while preserving `sourceType`-based wire serialization and compatibility decoding.
- Extend unified `tool-approval-request` / `tool-approval-response` parts with request `providerMetadata` and response `reason`.
- Add a first-class AI SDK-style UI-message type layer:
  `UiMessage`, `UiMessagePart`, `UiDataPart`, and `UiToolPart` now model the static
  `UIMessage` / `convertToModelMessages` boundary in the shared type crate.
- Extend unified `tool-approval-response` parts with optional `providerExecuted`, preserving the
  AI SDK approval-response routing hint on the stable content surface.
- Add first-class `providerOptions` to `ChatMessage`, request-capable `ContentPart` variants, and tool-result output/content shapes, including builder/helper APIs for stable mutation.
- Add first-class V4 `custom` / `reasoning-file` content parts plus explicit tool-result content variants (`file-data`, `file-url`, `file-id`, `image-data`, `image-url`, `image-file-id`) and a stable provider-keyed `ToolResultFileId`.
- Add first-class prompt-side provider-owned file/image references through shared
  `ProviderReference` plus `FilePartSource`, including `ContentPart::{image,file}_provider_reference(...)`
  and `ChatMessageBuilder::{with_image,with_file}_provider_reference(...)`.
- Add first-class runtime `ChatStreamPart` semantics and `ChatStreamEvent::Part`, so the stable streaming surface can carry AI SDK V4 stream-part concepts such as `source`, `response-metadata`, `stream-start warnings`, `finish`, `custom`, `file`, and `reasoning-file`.
- Add runtime-only `ChatStreamReplay` plus `ChatStreamEvent::PartWithReplay`, so protocol serializers can carry same-protocol replay hints such as OpenAI Responses `rawItem` / `outputIndex` without widening `ChatStreamPart` or overloading generic `providerMetadata`.
- Add first-class `ProviderType::{Azure, Cohere, TogetherAi, Bedrock}` variants so built-in native
  provider identity no longer needs to degrade those audited AI SDK-style providers to
  `Custom(...)`.
- Add first-class `ProviderType::{Mistral, Fireworks, Perplexity}` variants so the next
  AI SDK-packaged OpenAI-compatible provider ids no longer need to degrade to `Custom(...)` at the
  stable typing layer.
- Extend the shared image request family with top-level `aspectRatio` across generation/edit/variation
  plus shared `seed` on edit/variation, including builder/helper methods for the new canonical
  image call-option fields.
- Refactor `ImageVariationRequest` to carry a typed `ImageEditInput` file/url source image instead
  of a raw byte-only field, bringing the shared variation surface closer to AI SDK
  `ImageModelV4File`.
- Extend typed `ImageEditInput` file/url inputs with first-class per-input `providerOptions`,
  further aligning the shared image file shape with AI SDK `ImageModelV4File`.
- Extend typed `VideoGenerationInput` file/url inputs with first-class per-input
  `providerOptions`, aligning the shared video file shape more closely with AI SDK
  `VideoModelV4File`.
- Add canonical `AudioInputData` plus helper constructors/accessors, and refactor shared
  `SttRequest` / `AudioTranslationRequest` typing onto the AI SDK-style
  `audio + mediaType + providerOptions` surface instead of the older `audio_data | file_path`
  split.
- Add `ProviderType::DeepInfra`, so stable/provider catalog layers can model DeepInfra as a
  first-class provider instead of falling back to `Custom("deepinfra")`.
- Add `ProviderType::Vertex` and `ProviderType::AnthropicVertex`, extending the stable provider
  identity layer for the broader Google Vertex wrapper family alongside `VertexMaas`.
- `ChatResponse` now exposes optional stable `raw_finish_reason`, giving provider/protocol/extras
  layers one canonical slot for AI SDK-style raw finish metadata.

### Fixed

- `ChatResponse::reasoning()` and `ChatMessage::reasoning()` now ignore empty/whitespace reasoning
  parts, so metadata-only placeholders such as Anthropic `redacted_thinking` blocks no longer
  surface as fake empty reasoning strings through the stable helper API.
- Shared response-side provider metadata now reuses the same `ProviderMetadataMap` root across
  `ChatResponse`, `CompletionResponse`, stable content parts, stream metadata, and skill-upload
  results instead of each lane carrying a different nested-map convention. UI `providerMetadata`
  intentionally remains on `ProviderOptionsMap` because AI SDK `convertToModelMessages()` treats
  it as request-time `providerOptions`.
- Tool-result content parsing now accepts the newer AI SDK provider-reference aliases
  `file-reference` / `image-file-reference` plus `providerReference` payload keys alongside the
  existing `file-id` / `image-file-id` compatibility shape.
- Prompt-side `ContentPart::Audio.mediaType` and `ContentPart::File.mediaType` now serialize on
  the canonical AI SDK-style `mediaType` field while still accepting the legacy `media_type`
  alias during decode.
- `Usage` now tracks whether legacy totals are actually known, so builders, merges, serde, and normalized helpers stop materializing unknown compatibility totals as `0` when only partial AI SDK-style usage data is available.
- `Usage` no longer exposes legacy `prompt/completion/total` counts as public storage fields, so new code must use builders/constructors and compatibility accessors instead of struct literals or direct field reads.
- `Usage.merge()` now follows AI SDK `addLanguageModelUsage()` semantics more closely: token/accounting fields are aggregated, but provider-native `raw` usage is cleared on merge instead of being recursively combined into a synthetic payload.
- `ProviderOptionsMap` serde now normalizes provider ids during JSON decode and re-emits the canonical `openaiCompatible` wire key during encode, so JSON request fixtures and builder-authored requests share the same lookup behavior.
- `ResponseMetadata` now serializes the stable AI SDK field names `modelId` / `timestamp` while continuing to accept legacy `model` / `created` aliases during decode.
- Shared `SttRequest` / `AudioTranslationRequest` now require `mediaType` directly on the stable
  struct and constructor surface, so `from_audio(...)` / `from_base64(...)` align with the AI SDK
  required transcription input contract instead of leaving media type optional.
</blockquote>

## `siumai-core`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-core-v0.11.0-beta.7...siumai-core-v0.11.0-beta.8) - 2026-05-18

### Added

- reconnect google interactions streams

### Fixed

- *(openai-compatible)* preserve whitespace stream deltas

### Other

- guard core standards boundary
- *(clippy)* clean release lint failures
- *(release)* prepare v0.11.0-beta.8
- *(openai-compatible)* enforce lossless stream deltas
- harden spec core architecture guards
- remove static-header json executor helper
- remove dedicated vision compatibility surface
- route stream text fallback through response adapter
- converge provider boundary architecture
- move provider model aliases out of core
- harden crate boundaries
- converge fearless architecture boundaries
- *(examples)* move extras example index
- *(examples)* tighten example guidance
- *(deps)* refresh integration dependencies
- clean stale refactor docs

### Added

- Add a first-class completion family surface: `traits::CompletionCapability`,
  `completion::{CompletionModel, CompletionStream, CompletionStreamHandle}`,
  and `LlmClient::as_completion_capability()` now let family-first code execute completion models
  without falling back to chat-specific abstractions.
- Add a shared skill-upload surface aligned with AI SDK `SkillsV4`: canonical
  `SkillFileContent` / `SkillUploadFile` / `SkillUploadRequest` / `SkillUploadResult` now live on
  the shared type layer, `traits::SkillsCapability` is public, and `LlmClient` exposes
  `as_skills_capability()` for provider-owned skill resources such as OpenAI and Anthropic.
- Add a shared AI SDK-style UI-message helper surface:
  `ui::{validate_ui_messages, convert_to_model_messages, convert_to_chat_request}` now converts
  stable `UiMessage` values into canonical `ChatMessage` / `ChatRequest` structures, including
  assistant `step-start` block splitting, data-part callbacks, and incomplete-tool filtering.
- OpenAI-compatible route selection now also understands `RequestType::Completion`, so compat
  providers can resolve `/completions` through the shared adapter path instead of hard-coding
  chat-only routes.
- `OpenAiCompatibleConfig` now has an explicit `auth_required` flag so generic
  OpenAI-compatible providers can honestly model AI SDK's optional `apiKey` setting for local or
  private gateways without weakening built-in hosted-provider auth validation.

### Changed

- Rename the stable Rust text-family trait from `TextModelV3` to `TextModel`. The AI SDK-facing
  `LanguageModelV4` provider contract remains separate.

### Fixed

- Core OpenAI-compatible image response transformation now accepts provider wire
  `data[].b64_json` / `data[].url` responses directly and returns an AI SDK-style response
  envelope instead of requiring callers to pre-normalize image payloads into Siumai's unified
  struct.
- Shared stream factories now treat `ChatStreamPart::TextDelta` and
  `ChatStreamPart::ReasoningDelta` as the canonical runtime text/reasoning stream model.
- OpenAI-compatible Perplexity typed metadata now also preserves hosted-search
  `usage.reasoningTokens` instead of dropping that field while normalizing the response into the
  stable provider-rooted metadata surface.
- Shared stream wrappers now keep semantic-only streams semantic-only, so `StreamFactory` tail
  injection and `SimulateStreamingMiddleware` no longer append duplicate text after typed text
  parts.
- Shared provider metadata aggregation is now aligned around the spec-level
  `ProviderMetadataMap`: stream aggregation, OpenAI-compatible terminal metadata, and typed
  metadata accessors now all keep explicit provider-rooted object payloads instead of
  lane-specific nested `HashMap` conventions.
- OpenAI Responses cross-protocol bridging now prefers the stable semantic part lane: parseable
  legacy/custom typed stream-part payloads are promoted into `ChatStreamEvent::Part` /
  `PartWithReplay`, and `TypedStreamPart::to_runtime_part()` is public so adapters can
  project the typed overlay back into the runtime contract without reusing provider-prefixed
  custom events.
- Injectable HTTP transport parity now also covers non-stream `GET` / binary `GET` executor
  paths: `execute_get_request` and `execute_get_binary` now route through
  `HttpTransport::execute_get`, preserving per-request headers and retry/401-refresh behavior
  instead of bypassing custom transport wiring on provider-owned GET resources.
- OpenAI Chat request conversion now maps prompt-side provider-owned `image` / `file`
  references onto native `file_id` payloads, while OpenAI-compatible request conversion rejects
  those unsupported provider references explicitly instead of silently degrading them.
- OpenAI-compatible chat streaming now honors runtime raw-chunk emission on the stable part lane:
  `OpenAiCompatibleEventConverter::with_include_raw_chunks(true)` emits `raw` immediately after
  `stream-start` and before `response-metadata` on the first parsed chunk, matching the upstream
  AI SDK ordering more closely.
- OpenAI-compatible chat streaming now also preserves `stream-start` ordering on first-chunk parse
  failures: invalid JSON SSE payloads emit the stable `StreamStart` event/part before optional
  `raw` output and the final parse error, keeping the lifecycle closer to AI SDK's
  `start() -> raw? -> error` behavior.
- Stable response/stream finish propagation is now closer to AI SDK: `ChatResponse` carries
  `raw_finish_reason`, shared OpenAI-compatible chat decoding fills it from provider finish
  reasons, and `StreamProcessor` preserves raw finish reasons from terminal responses or stable
  `ChatStreamPart::Finish` parts when building final responses.
- OpenAI-compatible chat request/response shaping now also follows the audited AI SDK raw/camelCase
  provider-key contract more closely: provider-owned passthrough options merge raw + camelCase
  keys with camelCase taking precedence, compat response/finish metadata keep the resolved
  request-side namespace key with an explicit provider root, and Gemini-compatible
  `extra_content.google.thought_signature` now survives on finalized compat tool calls as
  `providerMetadata.{provider}.thoughtSignature`.
- `ClientWrapper` now forwards completion operations, and `ProviderCapabilities` tracks a native
  `completion` flag plus `supports("completion")`, so completion-capable clients can flow through
  generic runtime/registry adapters without losing capability checks.
- Provider-aware OpenAI-compatible usage parsing now supports DeepInfra-specific normalization:
  inconsistent `completion_tokens` / `reasoning_tokens` totals are corrected before the stable
  `Usage` model is built, and completion/stream decoding paths now route through that provider-aware
  parser instead of the generic usage parser.
- Stable provider typing now includes `ProviderType::DeepInfra`, and provider-aware retry/default
  validator helpers no longer downgrade DeepInfra to `Custom("deepinfra")`.
- Stable provider typing now also includes `ProviderType::Azure`, so provider-aware retry/default
  validator helpers no longer downgrade Azure OpenAI to `Custom("azure")`; the validator keeps
  Azure deployment ids permissive instead of pretending they are fixed OpenAI model names.
- Family routing variants now also collapse back to their canonical provider identity at the
  stable type layer: `openai-chat`, `openai-responses`, and `azure-chat` no longer read as fake
  custom providers when provider-aware retry/default-validator helpers inspect raw provider ids.
- Stable provider typing now also includes `ProviderType::Vertex` and
  `ProviderType::AnthropicVertex`, so provider-aware retry/default validator helpers no longer
  downgrade the Google Vertex native wrappers to `Custom(...)`.
- Provider-aware retry/default-validator helpers now also understand Vertex MaaS explicitly:
  Google-family backoff, default-model suggestions, stop-sequence limits, and model-family checks
  now treat `vertex-maas` as a first-class provider instead of a generic compat alias.
- Provider-aware retry/default-validator helpers now also understand Cohere, TogetherAI, and
  Bedrock explicitly instead of degrading those built-in providers to `Custom(...)`; Cohere now
  gets native model-family checks/default suggestions, TogetherAI now follows the OpenAI-compatible
  retry family explicitly, and Bedrock keeps a deliberate generic retry fallback.
- Provider-aware retry/default-validator helpers now also understand `mistral`, `fireworks`, and
  `perplexity` explicitly instead of degrading those AI SDK-packaged compat providers to
  `Custom(...)`; all three now follow the OpenAI-compatible retry family, and `mistral` also has a
  first-class embedding-default suggestion aligned with `mistral-embed`.
- OpenAI-compatible capability inference now also distinguishes chat-surface from
  completion-surface providers: `mistral` and `perplexity` no longer inherit completion capability
  just because they expose chat, while `fireworks` keeps explicit completion support.
- OpenAI-compatible chat/stream response decoding now normalizes usage through the shared AI SDK-style `inputTokens` / `outputTokens` / `raw` model instead of only preserving legacy totals and partial detail fields.
- The `TypedStreamPart` overlay is now a V4-capable superset with first-class `custom` and `reasoning-file` parts, and OpenAI-compatible `AsText` fallback can now degrade those parts into explicit text instead of silently dropping them.
- The upgraded typed stream-part overlay now also exposes public `LanguageModelV4*` provider-facing aliases alongside provider-agnostic `TypedStream*` names.
- `TypedStreamPart` can now convert to and from the new spec-level `ChatStreamEvent::Part(ChatStreamPart)` runtime semantic channel, and `EventBuilder` exposes a first-class `add_part(...)` helper.
- `EventBuilder` now also exposes `add_part_with_replay(...)`, and the shared stream processor / encoder helpers treat runtime replay-bearing part events the same as ordinary semantic part events.
- Anthropic `reasoning-*` typed custom-event conversion now preserves stable `id` and `providerMetadata`, so protocol serializers can replay AI SDK-style reasoning signatures and redacted-thinking metadata from the semantic part surface instead of dropping to ad hoc custom payloads.
- `StreamProcessor` now preserves terminal response envelope fields from `StreamEnd`, including `id`, `model`, `audio`, `system_fingerprint`, `service_tier`, and `warnings`.
- Final stream aggregation now falls back to `StreamStart` metadata when no terminal response is available and retains terminal multimodal parts that were not rebuilt from deltas, such as sources and provider-decorated tool calls.
- `StreamProcessor` now consumes structured runtime stream parts directly, preserving streamed warnings, finish reasons, provider metadata, sources, custom content, generated files, reasoning files, tool approval requests, and completed tool result parts instead of dropping them at the transport boundary.
- OpenAI Responses stream bridging now rebuilds provider-hosted tool / MCP replay as stable part events with a runtime replay carrier instead of synthesizing provider-scoped custom payloads with embedded `rawItem` JSON.
- OpenAI-compatible stream decoding now keeps observed terminal chunk fields such as `system_fingerprint` and `service_tier` on `StreamEnd`, including the EOF fallback path when no explicit finish chunk is emitted.
- OpenAI-compatible EOF / `[DONE]` fallback now also emits the missing stable semantic suffix on
  the direct `Part` lane: active `text-*` / `reasoning-*` parts are closed, unfinished tool-call
  lifecycles are finalized, and a stable `finish` part is emitted before the legacy `StreamEnd`.
- OpenAI-compatible streaming now matches AI SDK model-router metadata timing more closely: placeholder Azure `prompt_filter_results` preludes with empty `id` / `model` and `created = 0` no longer synthesize early `response-metadata` or `1970-01-01` timestamps before the first real metadata chunk arrives.
- OpenAI-compatible response metadata extraction is now owned by provider adapters instead of a shared compat-layer whitelist, aligning more closely with AI SDK `openai-compatible` `metadataExtractor` semantics: known providers explicitly opt into `sources` / `logprobs` / prediction-token extraction, Perplexity keeps its provider-specific hosted-search metadata, and generic compat providers no longer infer those fields by default.
- The compat adapter layer now exposes a public `ResponseMetadataExtractor` hook plus `MetadataExtractingAdapter`, allowing config/builders to inject AI SDK-style OpenAI-compatible response metadata extraction without replacing the full provider adapter.
- OpenAI-compatible request settings now also include AI SDK-style `includeUsage` / `queryParams` / `transformRequestBody` concepts: compat chat streams omit `stream_options.include_usage` unless the provider config opts in explicitly, `OpenAiCompatibleRequestSettings` now also carries deterministic provider-level URL query params into compat route generation, and callers can install a public `RequestBodyTransformer` hook that runs after provider normalization on the final request body.
- The compat request-settings lane now also exposes an explicit provider-level `supportsStructuredOutputs` policy for chat-completions shaping aligned with AI SDK: JSON Schema `response_format` requests now default to wire `json_object` unless callers explicitly enable structured outputs with `supportsStructuredOutputs = true`.
- OpenAI-compatible chat request normalization now also interprets the audited AI SDK known compat provider options from canonical `openaiCompatible` and provider-owned request keys: `user`, `reasoningEffort`, `textVerbosity`, and `strictJsonSchema` are mapped onto stable wire fields instead of being forwarded as raw camelCase extras.
- Shared URL joining now preserves existing query strings when appending paths, so provider specs such as OpenAI-compatible audio can safely compose `/audio/*` endpoints on top of query-bearing base URLs.
- OpenAI-compatible SSE serialization now reuses the shared OpenAI chat-usage writer, preserving usage detail fields and provider-unknown totals instead of flattening replayed `usage` chunks to synthetic zero-valued legacy integers.
- OpenAI-compatible replay of typed V3 `finish` parts now preserves unknown usage totals as `null` when no stable prompt/completion totals are available.
- Shared URL joining now preserves existing query strings and fragments when appending paths, so
  query-bearing endpoint composition such as OpenAI Files `/files?...` no longer corrupts the
  request path.
- OpenAI-compatible stream metadata extraction now falls back to the request model when early
  provider chunks omit `model`, fixing Azure model-router placeholder chunks that previously
  dropped stable `stream-start.model`.
- OpenAI-compatible chat/non-stream response decoding now maps `message.annotations` / `delta.annotations` URL citations into stable `source` parts, and URL `source` stream parts now serialize back into chat-completions `annotations`.
- `systemMessageMode=remove` warnings now use the explicit `compatibility` warning shape instead of a generic warning string.
- OpenAI-compatible and OpenAI Chat request conversion now read canonical message/part `providerOptions` for request-only behavior such as extra params, assistant reasoning replay hints, and image detail; request-side `provider_metadata` / `message.metadata.custom` are no longer treated as input on those main paths.
- Audio helper APIs such as `transcribe_file(...)` and `translate_file(...)` now materialize local
  files into canonical shared audio inputs before execution, and the audio executor no longer owns
  request-shape `file_path` fallback behavior.
- Audio convenience helpers now also follow the required `mediaType` contract of the shared
  transcription request types: `transcribe(...)` / `translate(...)` take explicit media types, and
  file-based helpers fail fast when a local path does not imply a recognizable audio media type.
- OpenAI-compatible config defaults now treat built-in `openrouter` and `perplexity` presets as
  structured-output-capable, so config-first public paths preserve JSON Schema response formats by
  default instead of falling back to generic `json_object`.
- The shared HTTP image executor now materializes `data:` / `http(s):` URL-backed edit and
  variation inputs before synchronous multipart/inline transformers run, so OpenAI,
  OpenAI-compatible, and Vertex image paths no longer reject typed URL inputs that can be
  centralized in the executor layer.
</blockquote>

## `siumai-protocol-anthropic`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-protocol-anthropic-v0.11.0-beta.7...siumai-protocol-anthropic-v0.11.0-beta.8) - 2026-05-18

### Other

- guard protocol custom stream inputs
- *(release)* prepare v0.11.0-beta.8
- converge provider boundary architecture
- harden crate boundaries
- converge fearless architecture boundaries
- *(examples)* move extras example index
- *(examples)* tighten example guidance
- clean stale refactor docs

### Fixed

- Anthropic header construction now supports the audited alternate-auth path: when callers provide
  an `Authorization` header and no API key, the protocol header builder no longer emits an empty
  `x-api-key`.
- Anthropic native structured output now follows the current AI SDK request contract more closely:
  native JSON Schema output lowers to `output_config.format` instead of deprecated
  `output_format`, request-option overlays merge `output_config.format`, `output_config.effort`,
  and `output_config.task_budget` onto one shared object instead of overwriting sibling fields,
  request normalization/bridge restoration now prefer `output_config.format` while remaining
  backward-compatible with legacy `output_format`, and stream-side structured-output mode
  selection now stays consistent with the final request body even when tools are present.
- Anthropic request-option normalization/body finalization now also preserve the remaining audited
  provider option fields more faithfully: `inferenceGeo` lowers to native `inference_geo`, and
  adaptive thinking `display` survives the normalize -> overlay -> finalize path instead of being
  dropped when Anthropic thinking is rebuilt.
- Anthropic container-skill request shaping now follows the current AI SDK public contract more
  closely: request overlays lower custom `providerReference.anthropic` values onto native
  `container.skills[].skill_id`, while same-protocol request normalization restores custom skills
  back onto `providerReference` instead of flattening every skill to `skillId`.
- Anthropic request and cache conversion now accept prompt-side provider-owned user image/document
  references, mapping them onto native `source: { type: "file", file_id }` blocks and resolving
  canonical `ProviderReference` entries only from the Anthropic provider namespace.
- Anthropic request finalization now auto-injects the `files-api-2025-04-14` beta token whenever
  prompt-side provider-owned file references require the Files API request path.
- Anthropic request-option normalization/body overlays now cover the newer AI SDK Anthropic
  request keys more completely (`thinking`, `sendReasoning`, `disableParallelToolUse`,
  `cacheControl`, `metadata.userId`, `mcpServers`, `contextManagement`, `speed`,
  `anthropicBeta`), and plain `anthropic-standard` builds no longer reference
  `MessageContent::Json` unless `structured-messages` is enabled.
- Anthropic request-body finalization now applies enabled-thinking token semantics consistently:
  final request bodies add `budget_tokens` onto `max_tokens` before known-model capping even when
  thinking came from legacy provider-specific params rather than only from provider options.
- Anthropic streaming now preserves extended usage fields such as `cache_creation_input_tokens`, `cache_read_input_tokens`, `server_tool_use`, and `service_tier` in terminal responses and SSE re-serialization, and terminal `Usage.raw` now keeps the full provider-native Anthropic usage object instead of a trimmed subset.
- Typed Anthropic metadata now distinguishes the narrow AI SDK-style `AnthropicMessageMetadata`
  shape from the wider Rust `AnthropicMetadata` helper, and `AnthropicChatResponseExt` exposes
  both `anthropic_message_metadata*()` and `anthropic_metadata*()` accessors accordingly.
- The narrow `AnthropicMessageMetadata.container` surface now also uses dedicated required-field
  message container/skill structs, while the wider `AnthropicMetadata` helper keeps tolerating
  partial container data for compatibility and intermediate replay paths.
- Typed Anthropic metadata extraction now derives nested `usage` fields and aliases consistently, so provider metadata round-trips keep raw usage fidelity.
- Anthropic Messages JSON replay now derives `input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, and `output_tokens` from the normalized AI SDK-style usage model when raw provider usage is missing or partial.
- Anthropic Messages response parsing now keeps the full provider-native `usage` payload on both `Usage.raw` and `provider_metadata.anthropic.usage`, so nested/forward-compatible Anthropic usage fields survive AI SDK-style raw snapshots instead of being trimmed to a local subset.
- Anthropic request conversion now degrades document-style unified `source` parts into text placeholders without assuming URL-only fields, preserving available title / filename / media type context.
- Anthropic Messages request conversion now prefers stable message/part `providerOptions` for cache control and document citation metadata, with legacy `metadata.custom` / `provider_metadata` paths retained only as compatibility fallbacks.
- Anthropic document citations/title/context and per-part cache control are now sourced only from canonical request-side `providerOptions.anthropic`; legacy `message.metadata.custom["anthropic_document_*"]`, `message.metadata.custom["anthropic_content_cache_*"]`, and request-side file `provider_metadata` no longer affect request conversion.
- Anthropic non-stream response parsing and same-protocol replay now keep `thinking` / `redacted_thinking` on stable reasoning parts instead of message-level shims: responses surface part-level `providerMetadata.anthropic.signature` / `redactedData`, prompt replay reads part-level Anthropic replay metadata, and Anthropic JSON replay no longer depends on `metadata.custom["anthropic_*"]` thinking keys.
- Anthropic custom provider ids now match the audited AI SDK contract more closely: request
  shaping merges canonical `providerOptions.anthropic` with provider-owned custom keys, custom
  keys override canonical fields when both are present, typed Anthropic metadata accessors now
  support custom roots, and top-level non-stream / finish / stream-end `providerMetadata`
  duplicates onto the custom provider root only when that custom request key was actually used.
- Anthropic response conversion now also matches the audited AI SDK source/message-metadata shape
  more closely: non-stream text citations and `web_search_tool_result` blocks emit stable
  `source` parts, request-scoped citation documents now feed the non-stream response transformer
  for document citation `title` / `filename` / `mediaType` resolution, source ids now use stable
  `id-*` generation across stream/non-stream citation and web-search sources, and absent
  `container` / `contextManagement` metadata now remains visible as explicit `null` on
  non-stream and final stream-end Anthropic provider metadata.
- Anthropic tool-result conversion and JSON replay now understand explicit Vercel-style `image-data`, `image-url`, `file-data` (PDF), and `file-url` content parts, while degrading unsupported file-id variants explicitly.
- Anthropic SSE serialization now accepts the new runtime `ChatStreamEvent::Part(ChatStreamPart)` semantic channel by bridging it through the typed stream-part compatibility path instead of assuming only legacy deltas or custom payloads, and it now normalizes those parts before locking serializer state so runtime-part replay cannot self-deadlock.
- Anthropic SSE serialization now also honors `UnsupportedStreamPartBehavior::AsText` on direct `ChatStreamEvent::Part/PartWithReplay` inputs, so unsupported stable parts such as `tool-approval-request` no longer disappear when the source stream is already on the typed runtime-part lane.
- Anthropic Messages SSE parsing now emits runtime AI SDK-style parts directly for `stream-start`, `response-metadata`, `text-*`, standard local `tool-input-*` / `tool-call`, `reasoning-*`, `source`, and successful `finish` semantics, and Anthropic SSE re-serialization now replays `tool-input-*` runtime parts without dropping block closures.
- Anthropic Messages SSE parsing now maps provider-hosted server tools and MCP tool use/results onto stable `tool-input-*` / `tool-call` / `tool-result` parts, and SSE replay now rebuilds provider-hosted Anthropic content blocks from that stable lane instead of depending on provider-scoped custom events.
- Anthropic Messages SSE `signature_delta` now maps to stable `reasoning-delta` parts with `providerMetadata.anthropic.signature`, `redacted_thinking` replay now follows `reasoning-start.providerMetadata.anthropic.redactedData`, and same-protocol replay no longer depends on the legacy `anthropic:thinking-signature-delta` custom event.
- Anthropic SSE message-delta replay now only injects `input_tokens` / `output_tokens` when the stable usage totals are actually known, so unknown finish usage no longer collapses to zero during stream reserialization.
- Anthropic Messages SSE now also preserves AI SDK-style first-chunk parse-failure lifecycle
  ordering: when the first SSE payload cannot be parsed, the stream still emits `stream-start`
  first, then optional runtime `raw`, and only then surfaces the parse error or API error.
</blockquote>

## `siumai-protocol-gemini`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-protocol-gemini-v0.11.0-beta.7...siumai-protocol-gemini-v0.11.0-beta.8) - 2026-05-18

### Fixed

- *(gemini)* gate structured response content branch
- repair release test regressions

### Other

- guard protocol custom stream inputs
- *(release)* prepare v0.11.0-beta.8
- converge provider boundary architecture
- harden crate boundaries
- converge fearless architecture boundaries
- *(examples)* move extras example index
- *(examples)* tighten example guidance
- clean stale refactor docs

### Fixed

- Gemini embedding response transformation now preserves an AI SDK-style response envelope with
  the raw response body on direct transformer usage.
- Gemini / Vertex reasoning streams now emit AI SDK-style custom `reasoning-start`,
  `reasoning-delta`, and `reasoning-end` events alongside stable runtime reasoning parts,
  preserving `providerMetadata.{google|vertex}.thoughtSignature` on the public stream surface.
- Gemini GenerateContent stream serialization now suppresses duplicate reasoning deltas when a
  bridge feeds the serializer both the typed `Part` lane and the mirrored Gemini custom
  `reasoning-delta` event for the same chunk.
- Gemini prompt/response conversion now honors the newer `FilePartSource` split consistently:
  image/file request conversion rejects provider-managed file references explicitly instead of
  mixing them with `MediaSource`, and response parsing now rebuilds image/file parts through
  `FilePartSource::{base64,url}` so `google` feature builds are green again after the
  provider-reference refactor.
- Gemini JSON response grounding metadata synthesis now accepts document-style unified `source` parts instead of assuming URL-only sources.
- Gemini tool-result conversion now handles explicit `image-data` content with preserved media types and stringifies unsupported explicit file/url/id variants predictably.
- Gemini JSON response usage replay now derives prompt/cache/text/reasoning totals from the normalized AI SDK-style usage model and preserves `trafficType` instead of dropping it at the type boundary.
- Gemini streaming serialization now accepts the new runtime `ChatStreamEvent::Part(ChatStreamPart)` semantic channel by routing it through the typed stream-part compatibility bridge, so reasoning/source/finish-style V4 parts no longer require provider-scoped custom events first.
- Gemini streaming parsing now emits first-class runtime stream parts for reasoning/source/provider-executed tool semantics and for `emit_v3_tool_call_parts=true` function-call paths instead of tunneling those AI SDK-stable semantics through `gemini:*` custom events.
- Gemini usage parsing/serialization now treats `candidatesTokenCount + thoughtsTokenCount` as total completion usage and preserves `cachedContentTokenCount` / `trafficType` across SSE round-trips without overwriting raw usage fields when stable totals are absent.
- Gemini request shaping now matches the upstream `google|vertex` namespace precedence fix more
  closely: request provider options and `thoughtSignature` replay use the runtime namespace first
  and fall back to the canonical sibling key only when needed.
- Gemini image request shaping now consumes canonical top-level `aspectRatio` / `seed` more
  consistently: Gemini image generation maps them into `generationConfig.imageConfig.aspectRatio`
  and `generationConfig.seed`, while Imagen request shaping now also honors provider-owned
  `aspectRatio` overrides with AI SDK-aligned precedence.
- Gemini GenerateContent SSE now also preserves AI SDK-style first-chunk parse-failure lifecycle
  ordering: invalid JSON on the first SSE payload emits `stream-start` before the parse error
  instead of skipping the stream lifecycle start entirely.
</blockquote>

## `siumai-protocol-openai`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-protocol-openai-v0.11.0-beta.7...siumai-protocol-openai-v0.11.0-beta.8) - 2026-05-18

### Added

- align openai metadata package surface
- *(openai)* support responses allowed tools option
- *(openai)* support gpt-image-2 image model

### Fixed

- require explicit compat completion capabilities
- *(openai-compatible)* extract generic response metadata
- *(openai)* preserve empty responses deltas
- *(openai)* preserve lossless stream deltas
- *(openai-compatible)* preserve whitespace stream deltas
- *(openai)* align image provider option wire keys
- *(openai)* align model capability gating with ai sdk

### Other

- *(openai-compatible)* centralize reasoning policy
- *(openai-compatible)* centralize usage policy
- prefer stable responses stream parts
- *(clippy)* clean release lint failures
- *(release)* prepare v0.11.0-beta.8
- *(openai)* unify completion request shaping
- *(openai)* unify completion response metadata
- *(openai)* unify completion metadata helpers
- *(openai-compatible)* enforce lossless stream deltas
- converge provider boundary architecture
- harden crate boundaries
- converge fearless architecture boundaries
- *(examples)* move extras example index
- *(examples)* tighten example guidance
- clean stale refactor docs

### Fixed

- OpenAI-compatible rerank response transformation now preserves an AI SDK-style response envelope
  with the raw response body before adapter normalization, so direct transformer usage keeps the
  same debugging metadata as the HTTP executor path.
- OpenAI and OpenAI-compatible embedding response transformation now also preserves an AI
  SDK-style response envelope with the raw response body on direct transformer usage.
- OpenAI-compatible Alibaba/Qwen chat request shaping now applies AI SDK-style prompt cache
  markers from message/part `providerOptions.alibaba|qwen.cacheControl` as Alibaba
  `cache_control` content-part fields, while keeping request-level `cacheControl` out of the
  top-level body.
- OpenAI Responses request conversion now maps prompt-side provider-owned user `image` / `file`
  references directly onto `input_image.file_id` / `input_file.file_id`, and request
  normalization converts incoming wire `file_id` items back into canonical stable
  `providerReference` parts without needing bridge-emitted `fileIdPrefixes`.
- OpenAI Responses and OpenAI-compatible usage parsing/serialization now converge on the shared AI SDK-style `inputTokens` / `outputTokens` / `raw` model, preserving provider-native `raw` usage plus `input_tokens_details.cached_tokens` and `output_tokens_details.reasoning_tokens` during JSON and SSE replay.
- OpenAI Responses request conversion now forwards `tool-approval-response.reason` on MCP approval items instead of dropping it.
- OpenAI Image request shaping now supports adapter-owned provider-options lookup hooks, so OpenAI-compatible image generation/edit/variation can merge provider-owned request fields from deprecated `openai-compatible`, canonical `openaiCompatible`, and provider-owned keys instead of hardcoding `providerOptions.openai|azure`.
- OpenAI and OpenAI-compatible image specs now surface AI SDK-style unsupported `aspectRatio` / `seed`
  warnings across generation, edit, and variation requests instead of only covering the generation
  seed case.
- OpenAI image variation multipart shaping now consumes the shared typed variation image input and
  explicitly rejects URL-backed variation inputs on the multipart path instead of assuming raw
  bytes only.
- OpenAI-compatible chat request/response shaping now also follows the audited AI SDK raw/camelCase
  provider-key contract more closely: provider-owned passthrough options merge raw + camelCase
  keys with camelCase taking precedence, non-stream and stream-finish provider metadata keep the
  resolved request-side namespace key with an explicit provider root, and Gemini-compatible
  `extra_content.google.thought_signature` now survives on compat tool calls as
  `providerMetadata.{provider}.thoughtSignature`.
- OpenAI typed metadata helpers now also expose keyed accessors for the shared provider-root
  contract (`*_metadata_with_key(...)`), bringing the OpenAI helper surface in line with the
  existing keyed Anthropic/Azure/DeepSeek patterns.
- OpenAI Responses request conversion now uses stable message/part/tool-result `providerOptions` as the canonical request-time lane for item ids, reasoning payloads, and image detail; assistant tool-call ids no longer read request-side `providerMetadata.openai`.
- OpenAI Responses request conversion now matches the stricter canonical provider boundary more closely: reasoning and compaction items no longer read request-side `provider_metadata`, encrypted reasoning without `itemId` is forwarded as a first-class reasoning item, tool-result approval-id skipping reads only output `providerOptions.openai`, image detail reads only part/tool-result `providerOptions`, and assistant tool-call ids now also stay on canonical `providerOptions`.
- OpenAI Responses request normalization now writes request-side `itemId`, `reasoningEncryptedContent`, and `imageDetail` back into canonical `providerOptions.openai` slots instead of response-style `provider_metadata.openai`, and `input_image` normalization now restores AI-SDK-shaped user image file parts rather than collapsing them into the older image-only shape.
- OpenAI Responses tool-result conversion now preserves explicit `file-data` / `file-url` / `file-id` / `image-data` / `image-url` / `image-file-id` shapes instead of collapsing them through a coarse image/file union.
- OpenAI Responses response decoding now also writes stable `raw_finish_reason` from
  `incomplete_details.reason`, so downstream response/extras layers can observe the provider-native
  raw finish cause without reparsing the raw payload.
- OpenAI-compatible chat response decoding now also preserves provider-native legacy
  `raw_finish_reason = "function_call"` while still normalizing the stable finish reason to
  `tool_calls`.
- OpenAI Responses request fixtures now lock native `file_id` roundtrips for tool-result `image-file-id` / `file-id`, and provider-keyed `ToolResultFileId` inputs now have regression coverage proving OpenAI-native ids win when projecting to Responses input items.
- OpenAI Responses fixture baselines now match the stable canonical model instead of older compatibility shapes: tool-result attachments no longer use the removed generic `file` variant, unsupported settings are asserted via `unsupported { feature }`, and exact response roundtrips now pin `Usage.inputTokens` / `Usage.outputTokens` / `Usage.raw`.
- OpenAI Responses exact request/response alignment now also preserves the audited stable tool
  structure more closely: provider-executed tool calls/results keep stable `dynamic` plus
  tool-result `input`, and hosted dynamic `local_shell` / `shell` / `apply_patch` items now
  serialize back to native Responses tool item types on the response bridge path instead of
  degrading to generic function/custom tool calls.
- OpenAI Responses SSE serialization now accepts the new runtime `ChatStreamEvent::Part(ChatStreamPart)` semantic channel directly by routing it through the typed stream-part compatibility bridge instead of requiring provider-scoped custom events first, and it now normalizes those parts before locking serializer state so direct part replay no longer self-deadlocks.
- OpenAI Responses SSE parsing now emits first-class runtime stream parts for `stream-start`, `response-metadata`, non-tool `text-*`, `reasoning-*`, `source`, successful `finish`, and provider-hosted tool / MCP / approval semantics, and document sources can now reserialize back to Responses annotations via `providerMetadata.openai.fileId` even when the stable source shape no longer carries a top-level document URL.
- OpenAI Responses same-protocol replay of provider-hosted tool / MCP / approval items now uses a dedicated runtime replay carrier for `rawItem` / `outputIndex`, so parser output, bridge output, and SSE serialization no longer depend on loose provider-scoped custom JSON extras for those hints.
- OpenAI Responses failed/unknown finish replay now preserves `null` usage totals end-to-end instead of materializing zero counts inside buffered terminal events.
- OpenAI audio multipart shaping now consumes the canonical shared transcription audio input,
  including base64-backed request payloads, instead of depending on the removed stable
  `audio_data | file_path` split.
- OpenAI STT multipart shaping now also requires and forwards the stable transcription
  `mediaType`, matching the AI SDK required-input contract instead of treating MIME attachment as
  optional.
</blockquote>

## `siumai-bridge`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/releases/tag/siumai-bridge-v0.11.0-beta.8) - 2026-05-18

### Other

- lock bridge stable stream parts
- *(release)* prepare v0.11.0-beta.8
- converge provider boundary architecture
- converge fearless architecture boundaries
</blockquote>

## `siumai-provider-amazon-bedrock`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-amazon-bedrock-v0.11.0-beta.7...siumai-provider-amazon-bedrock-v0.11.0-beta.8) - 2026-05-18

### Other

- *(release)* prepare v0.11.0-beta.8
- *(bedrock)* isolate chat stream conversion
- *(bedrock)* isolate chat standard tests
- converge provider boundary architecture
- harden crate boundaries
- *(examples)* move extras example index
- *(examples)* tighten example guidance
- clean stale refactor docs

### Added

- Native Bedrock provider now also exposes package-level `AmazonBedrockProviderSettings` plus
  `VERSION` on the provider-owned/public Rust surface. The new settings carrier keeps provider
  construction model-agnostic (`into_builder()`, `into_builder_for_model(...)`,
  `into_config_for_model(...)`), and the underlying builder/config surfaces now also expose honest
  header helpers (`headers(...)`, `header(...)`, `with_headers(...)`, `with_header(...)`) so the
  audited supported subset of AI SDK provider settings no longer requires raw HTTP-config
  mutation.

### Fixed

- Native Bedrock prompt conversion now rejects prompt-side provider-owned user file/image
  references explicitly on the request path, matching the audited AI SDK Bedrock limitation
  instead of leaving those inputs to ambiguous fallback handling.
- Native Bedrock prompt-conversion regression coverage now also locks URL-backed user `file`
  parts as unsupported on the request path, matching the upstream AI SDK Bedrock converter's
  no-URL policy for Converse documents/images.
- Native Bedrock chat responses and streamed terminal `ChatResponse` values now preserve the raw
  Bedrock `stopReason` on stable `raw_finish_reason` instead of dropping it after normalization.
- Native Bedrock Converse JSON streaming now emits an AI SDK-style first-chunk preamble on the
  stable stream lane: `stream-start`, stable `stream-start`, stable `response-metadata`,
  runtime-opt-in `raw`, then the Bedrock content/tool deltas.
- Native Bedrock Converse JSON streaming now also preserves first-chunk parse-failure lifecycle
  ordering more completely: invalid JSON chunks emit the stable preamble before optional runtime
  `raw` and the parse error, later valid chunks do not duplicate the preamble, and Bedrock
  provider error envelopes now surface stable `error` parts.
- Native Bedrock streamed terminal `ChatResponse` values now also preserve the default model,
  request warnings, and Bedrock `stopSequence` metadata on the stream path instead of dropping
  them during JSON-stream accumulation.
- Native Bedrock rerank response transformation now preserves an AI SDK-style response envelope
  with the raw response body even when callers use the provider transformer directly outside the
  HTTP executor path.
- Native Bedrock Converse JSON streaming now also emits stable AI SDK-style body semantics instead
  of staying legacy-delta-only: text, reasoning, tool-input, tool-call, and terminal finish
  parts are emitted on the main stream lane while the older `ContentDelta` / `ThinkingDelta` /
  `ToolCallDelta` / `StreamEnd` compatibility events remain available.
- Native Bedrock finish parts and non-stream chat responses now preserve more of the audited AI
  SDK payload shape: usage keeps cache-aware `inputTokens` totals plus raw usage, finish/provider
  metadata now carries `trace`, `performanceConfig`, `serviceTier`, `cacheWriteInputTokens`,
  `cacheDetails`, `stopSequence`, and `isJsonResponseFromTool`, streamed/non-stream responses now
  retain reasoning provider metadata plus default-model identity and request warnings, and
  Mistral-model tool call ids are normalized the same way as upstream AI SDK Bedrock.
- Native Bedrock request shaping now also preserves much more of the audited AI SDK option
  surface: `BedrockChatOptions` now includes typed `reasoningConfig`, `anthropicBeta`, and
  `serviceTier` alongside unknown top-level passthrough fields; Anthropic Bedrock requests now
  derive `additionalModelResponseFieldPaths`, `thinking`, `anthropic_beta`, and native
  `output_config.format` JSON-schema routing where upstream Bedrock uses it; and
  `maxReasoningEffort` now maps onto the same provider-specific Bedrock fields as upstream
  (`output_config.effort`, flat `reasoning_effort`, or nested `reasoningConfig`).
- Native Bedrock prompt conversion now also follows the upstream AI SDK Bedrock converter much
  more closely on the request path: message-level `cachePoint` survives on leading
  system/developer plus user/tool/assistant blocks, user `file` parts map to Bedrock
  `document` / `image` blocks with typed `citations` support and upstream filename stripping,
  assistant reasoning blocks replay `signature` / `redactedData` from canonical
  `providerOptions.bedrock`, tool-result `content` now supports `text` plus `image-data`, and
  request-side Mistral tool ids are normalized for both assistant tool calls and tool results.
- Bedrock now also exposes a typed reasoning replay helper on the public provider surface:
  `BedrockContentPartExt::bedrock_reasoning_metadata()` reads typed `signature` /
  `redactedData` from `ContentPart::Reasoning.provider_metadata["bedrock"]`, and
  `assistant_message_with_reasoning_metadata(...)` carries those fields back into next-turn
  request-side `providerOptions.bedrock`.

### Changed

- The provider-owned typed option surface now also exposes AI SDK-style
  `AmazonBedrockLanguageModelOptions` / `AmazonBedrockRerankingModelOptions` plus deprecated
  `BedrockProviderOptions` / `BedrockRerankingOptions` aliases for public migration parity.
</blockquote>

## `siumai-provider-anthropic`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-anthropic-v0.11.0-beta.7...siumai-provider-anthropic-v0.11.0-beta.8) - 2026-05-18

### Fixed

- align anthropic files capability surface

### Other

- *(release)* prepare v0.11.0-beta.8
- converge provider boundary architecture
- harden crate boundaries
- *(examples)* move extras example index
- *(examples)* tighten example guidance
- clean stale refactor docs

### Added

- Native Anthropic now exposes an AI SDK-style package settings wrapper:
  `AnthropicProviderSettings` covers the audited `apiKey` / `authToken` / `baseURL` / `headers` /
  `fetch` subset, converts into the provider-owned builder/config surfaces, and keeps upstream
  `generateId` / `name` explicitly deferred.
- Native Anthropic provider now also exposes a provider-owned `skills()` resource aligned with the
  AI SDK `AnthropicSkills` surface: multipart/base64 helpers upload to `POST /v1/skills`, the
  skill client automatically enables `skills-2025-10-02`, and canonical `providerReference` /
  `providerMetadata` are returned from the stable result shape.
- Native Anthropic request options now also expose typed task-budget support aligned with
  `anthropic-messages-options.ts`: `AnthropicTaskBudget`, `AnthropicTaskBudgetType`, and fluent
  builder/config helpers now own the `providerOptions.anthropic.taskBudget` surface directly.
- Native Anthropic typed options now also cover the remaining audited request enums more
  completely: `AnthropicInferenceGeo`, `AnthropicThinkingDisplay`, and `AnthropicEffort::Xhigh`
  are now first-class on the provider-owned/public surface.
- Native Anthropic package helpers now also expose
  `find_anthropic_container_id_from_last_step(...)` and
  `forward_anthropic_container_id_from_last_step(...)`, mirroring the upstream
  `forwardAnthropicContainerIdFromLastStep(...)` workflow for forwarding container ids across
  prepare-step history.

### Fixed

- Native Anthropic auth-token construction now maps `authToken` to `Authorization: Bearer ...`
  without forcing an empty `x-api-key`, matching the audited AI SDK alternate-auth path more
  closely.
- Native Anthropic provider metadata/spec wiring now advertises the Files API beta requirement for
  prompt-side provider-owned file references, keeping the public provider surface aligned with the
  audited request converter behavior.
- Native Anthropic spec/header inference now also matches the audited AI SDK task-budget contract:
  `taskBudget` enables the `task-budgets-2026-03-13` beta token, and structured-output capability
  checks now use the same native-output semantics as the final request-body builder instead of an
  older output-format-only heuristic.
- Native Anthropic request-option serde now preserves adaptive thinking `display` and the current
  upstream `xhigh` effort enum instead of narrowing those typed values away at the Rust facade
  boundary.
- Anthropic `skills()` upload now follows the audited AI SDK metadata path more closely: when the
  create response includes `latest_version`, the client also fetches
  `GET /v1/skills/{id}/versions/{version}` so version-scoped `name` / `description` win over the
  create-response copies.
- Anthropic thinking replay helper now maps response-side reasoning metadata onto next-turn `providerOptions.anthropic.signature` / `redactedData` on reasoning parts instead of writing legacy message-level `metadata.custom["anthropic_*"]` shims.
- Anthropic request-side typed options now align much more closely with
  `anthropic-messages-options.ts`: the public builder/config/facade surface covers typed
  `thinking`, `sendReasoning`, `disableParallelToolUse`, `cacheControl`, `metadata.userId`,
  `mcpServers`, `contextManagement`, `toolStreaming`, `effort`, `speed`, and `anthropicBeta`,
  and `container.skills` now uses a typed `AnthropicContainerSkillType` plus the audited
  discriminated union shape (`anthropic -> skillId`, `custom -> providerReference`) instead of
  flattening every entry onto one legacy struct.
- Anthropic enabled-thinking request shaping now also applies the upstream
  `max_tokens = maxOutputTokens + thinkingBudget` rule consistently, including legacy
  client-specific thinking configuration paths.
</blockquote>

## `siumai-provider-azure`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-azure-v0.11.0-beta.7...siumai-provider-azure-v0.11.0-beta.8) - 2026-05-18

### Added

- align azure metadata package surface

### Fixed

- repair release test regressions

### Other

- *(release)* prepare v0.11.0-beta.8
- converge provider boundary architecture
- harden crate boundaries
- *(examples)* move extras example index
- *(examples)* tighten example guidance
- clean stale refactor docs

### Added

- Native Azure OpenAI provider now also exposes package-level `AzureOpenAIProviderSettings` plus
  `VERSION` on the provider-owned/public Rust surface. The new settings carrier keeps provider
  construction model-agnostic (`into_builder()`, `into_builder_for_model(...)`,
  `into_config_for_model(...)`), Azure builder/config surfaces now also expose honest
  `resourceName` and header helpers, and audited package-level inputs such as `apiVersion` and
  `useDeploymentBasedUrls` now have a direct Rust-side settings carrier instead of only indirect
  builder/config wiring.

### Fixed

- Native Azure OpenAI completion now follows the AI SDK completion-family execution path on the
  real Azure `/completions` deployment route: non-stream and streamed calls preserve
  `api-version`, structured prompts follow the audited completion materialization rules, completion
  provider options merge audited OpenAI/Azure namespaces, and completion responses preserve raw
  `choices[0].logprobs` under provider-owned Azure metadata.
- Native Azure completion streaming now also honors runtime-only `includeRawChunks` on the audited
  `/completions` deployment route: stable `stream-start`, `raw`, `response-metadata`, `text-*`,
  and terminal `finish` parts are emitted while preserving legacy `ContentDelta` / `StreamEnd`.
- Native Azure completion streaming terminal responses now preserve raw provider finish reasons on
  stable `ChatResponse.raw_finish_reason` instead of dropping them at stream end.
- Azure content-part metadata helpers now preserve metadata on stable `reasoning-file` and
  `custom` parts in addition to the older content-part variants.
</blockquote>

## `siumai-provider-cohere`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-cohere-v0.11.0-beta.7...siumai-provider-cohere-v0.11.0-beta.8) - 2026-05-18

### Other

- *(release)* prepare v0.11.0-beta.8
- converge provider boundary architecture
- harden crate boundaries
- *(examples)* move extras example index
- *(examples)* tighten example guidance
- clean stale refactor docs

### Added

- Native Cohere `/v2` support now covers chat, embeddings, and rerank from the same provider
  crate, with public typed exports for `CohereClient`, chat/embed/rerank options, request
  extensions, and Cohere thinking/embedding enums.
- Curated Cohere `chat` / `embedding` / `rerank` model constants are now exported from the provider
  package, alongside AI SDK-style option aliases
  (`CohereLanguageModelOptions`, `CohereEmbeddingModelOptions`,
  `CohereRerankingModelOptions`) and deprecated migration aliases for side-by-side compile checks.
- Native Cohere provider now also exposes package-level `CohereProviderSettings` plus `VERSION` on
  the provider-owned/public Rust surface. The new settings carrier keeps provider construction
  model-agnostic (`into_builder()`, `into_builder_for_model(...)`, `into_config_for_model(...)`),
  and the underlying builder/config surfaces now expose honest header helpers instead of requiring
  indirect HTTP-config mutation for audited package-level header parity.

### Changed

- The canonical native Cohere path now requires an explicit model id instead of inheriting the old
  rerank-biased provider-wide default model.

### Fixed

- The provider crate now matches the audited AI SDK `@ai-sdk/cohere` architecture more closely:
  the native package is no longer rerank-only, and the OpenAI-compatible Cohere preset is no
  longer the canonical embedding story.
- Native Cohere chat now mirrors the audited AI SDK provider-defined-tool warning behavior more
  closely: provider-defined tools are filtered from `/v2/chat` requests but still surface as
  stable `unsupported { feature: "provider-defined tool <id>" }` warnings on both non-stream
  responses and streamed terminal `ChatResponse` values.
- Native Cohere chat streaming now also emits a stable `StreamStart` part plus runtime `raw`
  chunks when `includeRawChunks` is enabled, bringing the stream lane closer to the audited AI SDK
  `stream-start -> raw -> response-metadata -> ...` order.
- Native Cohere chat streaming now also preserves first-chunk parse-failure lifecycle ordering:
  invalid SSE payloads emit `stream-start` before optional runtime `raw` and the parse error, and
  a later real `message-start` chunk no longer duplicates the stream-start event after that
  fallback path.
- Native Cohere chat responses and streamed terminal `ChatResponse` values now preserve the raw
  Cohere `finish_reason` on stable `raw_finish_reason` instead of dropping it after normalization.
- Cohere embedding request shaping now also enforces the audited AI SDK `outputDimension` contract
  (`256`, `512`, `1024`, or `1536`) instead of silently accepting arbitrary values.
- Cohere embedding execution now also enforces the audited AI SDK batch-size guard: one native
  `/v2/embed` call may carry at most `96` inputs.
- Cohere rerank response transformation now preserves an AI SDK-style response envelope with the
  raw response body even when callers use the provider transformer directly outside the HTTP
  executor path.
- Native Cohere chat response transformation now builds against the current shared
  response-metadata field.
</blockquote>

## `siumai-provider-openai-compatible`

<blockquote>

## [0.11.0-beta.8](https://github.com/YumchaLabs/siumai/compare/siumai-provider-openai-compatible-v0.11.0-beta.7...siumai-provider-openai-compatible-v0.11.0-beta.8) - 2026-05-18

### Added

- add google vertex xai provider boundary

### Fixed